### PR TITLE
Added new snippets for Ember 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Or Settings ➔ Packages ➔ Search for `atom-handlebars`
 ## Snippets
 
 - `each` ⇥
+- `eachas` ⇥
+- `eachin` ⇥
+- `get` ⇥
 - `list` ⇥
 - `if` ⇥
 - `ifelse` ⇥

--- a/snippets/atom-handlebars.cson
+++ b/snippets/atom-handlebars.cson
@@ -25,6 +25,28 @@
       {{/each}}
     """
 
+  'Handlebars: Each As':
+    'prefix': 'eachas'
+    'body': """
+      {{#each ${1:${2:item} ${3:as |${4:value}|}}}}
+        ${5}
+      {{/each}}
+    """
+
+  'Handlebars: Each In':
+    'prefix': 'eachin'
+    'body': """
+      {{#each-in ${1:${2:item} ${3:as |${4:value}|}}}}
+        ${5}
+      {{/each}}
+    """
+
+  'Handlebars: Get':
+    'prefix': 'get'
+    'body': """
+      {{get ${1:${2:item} ${3:value}}}}
+    """
+
   'Handlebars: List':
     'prefix': 'list'
     'body': """


### PR DESCRIPTION
There are some new ways to call `each` in handlebars templates with the introduction of Ember2.0.

I wanted to add these in, as the previous form of each is deprecated.