### PR TITLE
Add forward slash as valid character in helpers/blocks

### DIFF
--- a/grammars/html (handlebars).cson
+++ b/grammars/html (handlebars).cson
@@ -29,7 +29,7 @@
 
   # Helpers
   {
-    'begin': '\\{\\{([\\w-]*\\s|else)'
+    'begin': '\\{\\{(\\w[\\w\/-]*\\s|else)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.handlebars'
@@ -55,7 +55,7 @@
 
   # Block expressions
   {
-    'begin': '\\{\\{([#^])([\\w-]*)'
+    'begin': '\\{\\{([#^])(\\w[\\w\/-]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.handlebars'
@@ -87,7 +87,7 @@
 
   # Close - Block expressions
   {
-    'begin': '\\{\\{(/)([\\w-]*)'
+    'begin': '\\{\\{(/)(\\w[\\w\/-]*)'
     'beginCaptures':
       '0':
         'name': 'entity.name.tag.handlebars'


### PR DESCRIPTION
In Ember, when using the ember-cli resolver, components are allowed to have a slash in their name as a way to lookup component names nested directories, e.g.

```handlebars
{{#some-dir/some-component foo=bar}}
  ...
{{/some-dir/some-component}}
```

Note that I also added a leading `\w` to the block/helper name to ensure the first character is an alpha -- let me know if allowing a leading dash (`{{-foo bar}}`) is actually valid.