### PR TITLE
Fix {{#each-in}} mismatch

### DIFF
--- a/snippets/atom-handlebars.cson
+++ b/snippets/atom-handlebars.cson
@@ -38,7 +38,7 @@
     'body': """
       {{#each-in ${1:${2:item} ${3:as |${4:value}|}}}}
         ${5}
-      {{/each}}
+      {{/each-in}}
     """
 
   'Handlebars: Get':


### PR DESCRIPTION
Simply replace {{/each}} with {{/each-in}} to fix compiler error