### PR TITLE
Add space after unless in its snippet

### DIFF
--- a/snippets/atom-handlebars.cson
+++ b/snippets/atom-handlebars.cson
@@ -80,7 +80,7 @@
   'Handlebars: Unless':
     'prefix': 'unless'
     'body': """
-      {{#unless${1: item}}}
+      {{#unless ${1: item}}}
         ${2}
       {{/unless}}
     """


### PR DESCRIPTION
Hi,

thanks for this package.

I think the `unless` snippet gets set so that there's no space between `unless` and the following condition.

Added that space.

All the best!
