### PR TITLE
Adds grammar rule for dot and slash delimited components

### DIFF
--- a/grammars/html (handlebars).cson
+++ b/grammars/html (handlebars).cson
@@ -28,6 +28,34 @@
     'name': 'meta.tag.template.raw.handlebars'
   }
 
+  # Contextual Components and "Slashy" Components
+  {
+    'begin': '\\{\\{~?(\\w[\\w\/-]*)[\\.\/](\\w[\\w\/-]*)'
+    'beginCaptures':
+      '0':
+        'name': 'entity.name.tag.handlebars'
+      '1':
+        'name': 'entity.name.function.handlebars'
+      '2':
+        'name': 'entity.name.function.handlebars'
+    'end': '~?\\}\\}'
+    'endCaptures':
+      '0':
+        'name': 'entity.name.tag.handlebars'
+    'name': 'meta.tag.template.handlebars'
+    'patterns': [
+      {
+        'include': '#generic-attribute'
+      }
+      {
+        'include': '#string-double-quoted'
+      }
+      {
+        'include': '#string-single-quoted'
+      }
+    ]
+  }
+
   # Helpers
   {
     'begin': '\\{\\{~?(\\w[\\w\/-]*\\s|else)'

--- a/spec/handlebars-spec.coffee
+++ b/spec/handlebars-spec.coffee
@@ -112,3 +112,35 @@ describe 'Handlebars grammar', ->
     expect(tokens[0]).toEqual value: '{{~', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
     expect(tokens[2]).toEqual value: '~}}', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
 
+  it 'parses contextual components and "slashy" components', ->
+    {tokens} = grammar.tokenizeLine("{{aaa.yyy-zzz}}")
+
+    expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[1]).toEqual value: 'aaa', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[2]).toEqual value: '.', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[3]).toEqual value: 'yyy-zzz', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[4]).toEqual value: '}}', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+
+    {tokens} = grammar.tokenizeLine("{{aaa-bbb.yyy-zzz}}")
+
+    expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[1]).toEqual value: 'aaa-bbb', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[2]).toEqual value: '.', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[3]).toEqual value: 'yyy-zzz', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[4]).toEqual value: '}}', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+
+    {tokens} = grammar.tokenizeLine("{{aaa/yyy-zzz}}")
+
+    expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[1]).toEqual value: 'aaa', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[2]).toEqual value: '/', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[3]).toEqual value: 'yyy-zzz', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[4]).toEqual value: '}}', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+
+    {tokens} = grammar.tokenizeLine("{{aaa-bbb/yyy-zzz}}")
+
+    expect(tokens[0]).toEqual value: '{{', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[1]).toEqual value: 'aaa-bbb', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[2]).toEqual value: '/', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[3]).toEqual value: 'yyy-zzz', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars', 'entity.name.function.handlebars']
+    expect(tokens[4]).toEqual value: '}}', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']


### PR DESCRIPTION
Fixes #45 and highlights component declared without parameters when using the `.` or `/` separator.