### PR TITLE
Fixed handing of whitespace control characters

### DIFF
--- a/grammars/html (handlebars).cson
+++ b/grammars/html (handlebars).cson
@@ -8,20 +8,20 @@
 
   # Comments
   {
-    'begin': '\\{\\{!--'
-    'end': '--\\}\\}'
+    'begin': '\\{\\{~?!--'
+    'end': '--~?\\}\\}'
     'name': 'comment.block.handlebars'
   }
   {
-    'begin': '\\{\\{!'
-    'end': '\\}\\}$'
+    'begin': '\\{\\{~?!'
+    'end': '~?\\}\\}$'
     'name': 'comment.block.handlebars'
   }
 
   # Escape
   {
-    'begin': '\\{\\{\\{~?'
-    'end': '~?\\}\\}\\}'
+    'begin': '\\{\\{~?\\{'
+    'end': '\\}~?\\}\\}'
     'captures':
       '0':
         'name': 'entity.name.tag.handlebars'

--- a/spec/handlebars-spec.coffee
+++ b/spec/handlebars-spec.coffee
@@ -111,6 +111,18 @@ describe 'Handlebars grammar', ->
     {tokens} = grammar.tokenizeLine("{{~else~}}")
     expect(tokens[0]).toEqual value: '{{~', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
     expect(tokens[2]).toEqual value: '~}}', scopes: ['text.html.handlebars', 'meta.tag.template.handlebars', 'entity.name.tag.handlebars']
+    
+    {tokens} = grammar.tokenizeLine("{{~{variable}~}}")
+    expect(tokens[0]).toEqual value: '{{~{', scopes: ['text.html.handlebars', 'meta.tag.template.raw.handlebars', 'entity.name.tag.handlebars']
+    expect(tokens[2]).toEqual value: '}~}}', scopes: ['text.html.handlebars', 'meta.tag.template.raw.handlebars', 'entity.name.tag.handlebars']
+
+    {tokens} = grammar.tokenizeLine("{{~!comment~}}")
+    expect(tokens[0]).toEqual value: '{{~!', scopes: ['text.html.handlebars', 'comment.block.handlebars']
+    expect(tokens[2]).toEqual value: '~}}', scopes: ['text.html.handlebars', 'comment.block.handlebars']
+
+    {tokens} = grammar.tokenizeLine("{{~!--\ncomment\n--~}}")
+    expect(tokens[0]).toEqual value: '{{~!--', scopes: ['text.html.handlebars', 'comment.block.handlebars']
+    expect(tokens[2]).toEqual value: '--~}}', scopes: ['text.html.handlebars', 'comment.block.handlebars']
 
   it 'parses contextual components and "slashy" components', ->
     {tokens} = grammar.tokenizeLine("{{aaa.yyy-zzz}}")


### PR DESCRIPTION
Comments and triple-stache expressions were not compatible with `~` whitespace control characters. This pull request adds support for the following syntaxes to allow proper code highlighting when using the control character to remove extra whitespace:
```
{{~! single line comment ~}}
```
```
{{~!-- multiple line 
comment --~}}
```
```
{{~{ nonEscapedExpression }~}}
```

The existing syntax for triple-stache non-escaped expressions was invalid (`{{{~ expr ~}}}`) which may be why there was no test for that specific case.